### PR TITLE
Mak/polish UI

### DIFF
--- a/src/app/badges/[id]/page.tsx
+++ b/src/app/badges/[id]/page.tsx
@@ -18,11 +18,16 @@ interface Props {
 }
 
 const TitleBar = ({ owned }: { owned: boolean }) => (
-  <Stack alignItems="center" marginTop="24px">
+  <Stack
+    alignItems="center"
+    marginTop="24px"
+    position={'relative'}
+    width={'100%'}
+  >
     <Box
       sx={{
         position: 'absolute',
-        left: 20,
+        left: '20px',
       }}
     >
       <Link href="/badges">

--- a/src/app/badges/page.tsx
+++ b/src/app/badges/page.tsx
@@ -301,6 +301,12 @@ export default function Badges() {
               anchor={anchor}
               open={drawerStates.walletOperations[anchor]}
               onClose={() => handleToggleDrawer(anchor)}
+              PaperProps={{
+                style: {
+                  width: '390px',
+                  left: 'calc(50% - 195px)', // 50% - half of width
+                },
+              }}
             >
               {list(anchor)}
             </Drawer>

--- a/src/app/badges/page.tsx
+++ b/src/app/badges/page.tsx
@@ -292,7 +292,7 @@ export default function Badges() {
 
   return (
     <>
-      <Box paddingX="1.25rem">
+      <Box paddingX="1.25rem" marginBottom={7}>
         <Hero />
         <Box>{BadgesWrapper}</Box>
         {(['bottom'] as const).map((anchor) => (

--- a/src/components/Badges/BadgeStack.tsx
+++ b/src/components/Badges/BadgeStack.tsx
@@ -1,6 +1,7 @@
 import { BadgeTypeEnum } from '@/hooks/types';
 import { Box } from '@mui/material';
 import Image from 'next/image';
+import { useCallback } from 'react';
 
 type Props = {
   panel: BadgeTypeEnum;
@@ -9,10 +10,15 @@ type Props = {
 };
 
 function BadgeStack({ panel, toggleFunction, hide }: Props) {
+  const handleToggle = useCallback(() => {
+    toggleFunction(panel);
+  }, [panel, toggleFunction]);
+
   if (hide) return null;
+
   return (
     <Box
-      onClick={() => toggleFunction(panel)}
+      onClick={handleToggle}
       sx={{
         justifyContent: 'space-between',
         alignSelf: 'stretch',

--- a/src/components/Badges/BadgeStack.tsx
+++ b/src/components/Badges/BadgeStack.tsx
@@ -12,6 +12,7 @@ function BadgeStack({ panel, toggleFunction, hide }: Props) {
   if (hide) return null;
   return (
     <Box
+      onClick={() => toggleFunction(panel)}
       sx={{
         justifyContent: 'space-between',
         alignSelf: 'stretch',
@@ -38,7 +39,6 @@ function BadgeStack({ panel, toggleFunction, hide }: Props) {
         height={80}
       />
       <Box
-        onClick={() => toggleFunction(panel)}
         sx={{
           color: 'var(--Dark-Blue, #0a25a5)',
           fontFeatureSettings: '"clig" 0, "liga" 0',

--- a/src/components/Badges/SwipeUpDrawer.tsx
+++ b/src/components/Badges/SwipeUpDrawer.tsx
@@ -97,6 +97,12 @@ function SwipeUpDrawer({
         onOpen={() => toggleDrawer(type, anchor, true)}
         swipeAreaWidth={drawerBleeding}
         disableSwipeToOpen={false}
+        PaperProps={{
+          style: {
+            width: '390px',
+            left: 'calc(50% - 195px)', // 50% - half of width
+          },
+        }}
         ModalProps={{
           keepMounted: true,
         }}


### PR DESCRIPTION
- Bigger touch/click targets (you can click the account, and the stacked images)

- Clamped Drawers
![image](https://github.com/sizzle-squad/base-hunt/assets/9060170/6ae01ba1-1101-4a8f-8f99-4934df853371)
![image](https://github.com/sizzle-squad/base-hunt/assets/9060170/6f7eb514-559e-45e2-be55-f38bb7792431)


- Avoid cutoff due to bottom nav
![image](https://github.com/sizzle-squad/base-hunt/assets/9060170/34b5ae3e-56a2-43e3-a2fc-91f29e72d31a)

