### PR TITLE
update top-rank query to also order by updated_at asc

### DIFF
--- a/src/app/api/treasure-box/top-ranks/route.ts
+++ b/src/app/api/treasure-box/top-ranks/route.ts
@@ -24,6 +24,7 @@ export async function GET(request: NextRequest) {
     .select('*')
     .eq('game_id', BigInt(gameId))
     .order('total_hitpoints', { ascending: false })
+    .order('updated_at', { ascending: true })
     .limit(10);
 
   if (error) {


### PR DESCRIPTION
add the secondary order by `updated_at` to match how `getuserrank` function works