### PR TITLE
add score based leaderboard apis

### DIFF
--- a/src/app/api/leaderboard/rank/route.ts
+++ b/src/app/api/leaderboard/rank/route.ts
@@ -1,0 +1,76 @@
+import { NextResponse, type NextRequest } from 'next/server';
+import '@/utils/helper';
+import { createClient } from '@supabase/supabase-js';
+import { toBigInt } from '@/utils/toBigInt';
+
+type RankType = {
+  rank: number;
+  user_address: string;
+  current_score: number;
+};
+
+const supabase = createClient(
+  process.env.SUPABASE_URL as string,
+  process.env.SUPABASE_ANON_KEY as string
+);
+
+export async function GET(request: NextRequest) {
+  const searchParams = request.nextUrl.searchParams;
+  const userAddress = searchParams.get('userAddress');
+  const gameId = toBigInt(searchParams.get('gameId') as string);
+
+  if (!userAddress || gameId === null) {
+    return new Response(
+      `Missing parameters: userAddress: ${userAddress}, gameId: ${gameId}`,
+      {
+        status: 400,
+      }
+    );
+  }
+  const rankData = await supabase.rpc('getscorerank', {
+    _game_id: gameId,
+    _user_address: userAddress,
+  });
+  if (rankData.error) {
+    console.log(rankData.error);
+    return new Response('', { status: 500 });
+  }
+  const rank = rankData.data;
+  if (rank.length === 0) {
+    return NextResponse.json({
+      rank: null,
+      userAddress: userAddress,
+      currentScore: 0,
+    });
+  }
+
+  const playerRank = rank[0].j as RankType;
+  return NextResponse.json({
+    rank: playerRank?.rank.toString(),
+    userAddress: playerRank?.user_address,
+    currentScore: playerRank?.current_score,
+  });
+}
+
+/*
+database function:
+
+create or replace function getscorerank(
+    _game_id bigint,
+    _user_address text
+) 
+returns table ( j json ) 
+language plpgsql
+as $$
+declare 
+
+begin
+ RETURN QUERY  select to_json(temp.*) from (select rank() over (order by current_score desc, updated_at asc) as rank, 
+    user_address as user_address, current_score from score where game_id = _game_id and user_address ilike _user_address)  as temp;
+end; 
+$$
+
+
+$$
+
+*/

--- a/src/app/api/leaderboard/route.ts
+++ b/src/app/api/leaderboard/route.ts
@@ -1,0 +1,44 @@
+import { NextResponse, type NextRequest } from 'next/server';
+import '@/utils/helper';
+import { createClient } from '@supabase/supabase-js';
+import { Database } from '@/utils/database.types';
+import { toBigInt } from '@/utils/toBigInt';
+
+const supabase = createClient<Database>(
+  process.env.SUPABASE_URL as string,
+  process.env.SUPABASE_ANON_KEY as string
+);
+
+// return top 10 ranks
+export async function GET(request: NextRequest) {
+  const searchParams = request.nextUrl.searchParams;
+  const gameId = toBigInt(searchParams.get('gameId') as string);
+
+  if (gameId === null) {
+    return new Response(`Missing parameters: gameId: ${gameId}`, {
+      status: 400,
+    });
+  }
+  const { data, error } = await supabase
+    .from('score')
+    .select('*')
+    .eq('game_id', BigInt(gameId))
+    .order('current_score', { ascending: false })
+    .order('updated_at', { ascending: true })
+    .limit(10);
+
+  if (error) {
+    return new Response(`No top ranks found with gameId: ${gameId}`, {
+      status: 400,
+    });
+  }
+
+  const result = data.map((entry) => ({
+    updatedAt: entry.updated_at,
+    gameId: entry.game_id,
+    currentScore: entry.current_score,
+    userAddress: entry.user_address,
+  }));
+
+  return NextResponse.json(result);
+}


### PR DESCRIPTION
This PR adds 2 new endpoints to get leader board and rank based on user score not tap score:

1. current users rank:

`/api/leaderboard/rank?gameId=userAddress=`
 
```
{
   rank: string | null,
   userAddress: string,
   currentScore: number,
 }
```

2. top 10 scores :

` /api/leaderboard?gameId=`

```
[{
   updatedAt: Date,
   gameId: number,
   currentScore: number,
   userAddress: string,
 }]
```
