### PR TITLE
moved challenge to home page

### DIFF
--- a/src/app/(drawerPages)/(detailPages)/boosts/BoostsClient.tsx
+++ b/src/app/(drawerPages)/(detailPages)/boosts/BoostsClient.tsx
@@ -324,7 +324,6 @@ export default function BoostsPageClient() {
 
   return (
     <>
-      <DetailsPageNavbar title={PageConsts.navTitle} />
       <NoSsr>
         <Stack gap={2}>
           {isLoading &&

--- a/src/app/(drawerPages)/(detailPages)/boosts/page.tsx
+++ b/src/app/(drawerPages)/(detailPages)/boosts/page.tsx
@@ -1,4 +1,3 @@
-import { Stack } from '@mui/material';
 import BoostsPageClient from './BoostsClient';
 
 export default function Page() {

--- a/src/app/(drawerPages)/badges/page.tsx
+++ b/src/app/(drawerPages)/badges/page.tsx
@@ -36,6 +36,7 @@ import Link from 'next/link';
 import { useRouter } from 'next/navigation';
 import { Fragment, useCallback, useEffect, useMemo, useState } from 'react';
 import { useAccount, useDisconnect } from 'wagmi';
+import BoostsPageClient from '../(detailPages)/boosts/BoostsClient';
 
 type Anchor = 'top' | 'left' | 'bottom' | 'right';
 
@@ -91,7 +92,7 @@ export default function Badges() {
   const handleDisconnect = useCallback(async () => {
     await disconnectAsync();
     router.push('/');
-  }, [disconnectAsync]);
+  }, [disconnectAsync, router]);
 
   const handleDrawerDismiss = useCallback(() => {
     toggleDrawer('walletOperations', 'bottom', false);
@@ -121,7 +122,7 @@ export default function Badges() {
     if (isDisconnected) {
       router.push('/');
     }
-  }, [isDisconnected]);
+  }, [isDisconnected, router]);
 
   const BadgesWrapper = useMemo(() => {
     if (isClient) {
@@ -371,7 +372,6 @@ export default function Badges() {
             score={score as number}
           />
         </Stack>
-        {BadgesWrapper}
         <Box>
           {(['bottom'] as const).map((anchor) => (
             <Fragment key={anchor}>
@@ -385,7 +385,9 @@ export default function Badges() {
             </Fragment>
           ))}
         </Box>
+        <BoostsPageClient />
       </Stack>
+
       <BootstrapDialog
         onClose={() => setShowModal(false)}
         aria-labelledby="customized-dialog-title"

--- a/src/components/navigation/navbar/NavbarClient.tsx
+++ b/src/components/navigation/navbar/NavbarClient.tsx
@@ -72,22 +72,6 @@ export const NavbarClient = () => {
           )}
         </Stack>
       </Stack>
-      <Link href="/boosts">
-        <Pill backgroundColor="blue">
-          <Text color="white" fontSize="14px" fontWeight="bold">
-            Get Points
-          </Text>
-          <svg
-            width="5"
-            height="9"
-            viewBox="0 0 5 9"
-            fill="none"
-            xmlns="http://www.w3.org/2000/svg"
-          >
-            <path d="M1 8.5L4 4.5L1 0.5" stroke="white" strokeWidth="1.5" />
-          </svg>
-        </Pill>
-      </Link>
     </Stack>
   );
 };


### PR DESCRIPTION
1. Remove boost pills from navbar
2. Delete badge collections
3. Move challenges (boosts) to home page.

<img width="1748" alt="Screenshot 2024-01-18 at 2 36 51 PM" src="https://github.com/sizzle-squad/base-hunt/assets/136514599/b1bf817f-c235-4501-8664-77d97fc1d3a4">
