### PR TITLE
add paginated ranks

### DIFF
--- a/src/app/api/leaderboard/route.ts
+++ b/src/app/api/leaderboard/route.ts
@@ -10,6 +10,7 @@ const supabase = createClient<Database>(
   process.env.SUPABASE_ANON_KEY as string
 );
 
+// return paginated leaderboard
 export async function GET(request: NextRequest) {
   const searchParams = request.nextUrl.searchParams;
   const gameId = toBigInt(searchParams.get('gameId') as string);


### PR DESCRIPTION
Added pagination to /leaderboard 
updated documentation here https://docs.google.com/document/d/1ZiOO8c9rzXig7OQlyEHuJlF8nF18E_dodIf9_6uz_iQ/edit#heading=h.glif4q6oh9i1 


Fetches leaderboard paginated with `page` (default 1) and `perPage` (default 100, max 200)