### PR TITLE
add badges endpoint

### DIFF
--- a/src/app/api/badges/route.ts
+++ b/src/app/api/badges/route.ts
@@ -1,0 +1,67 @@
+import { createClient } from '@supabase/supabase-js';
+import { type NextRequest, NextResponse } from 'next/server';
+import '@/utils/helper';
+
+import { BadgeState, ChallengeMetricsState } from '@/hooks/types';
+import { Database } from '@/utils/database.types';
+import { toBigInt } from '@/utils/toBigInt';
+
+const supabase = createClient<Database>(
+  process.env.SUPABASE_URL as string,
+  process.env.SUPABASE_SERVICE_KEY as string
+);
+
+interface BadgeDataType {
+  badge_id: number;
+  badge_name: string;
+  challenge_id: string;
+  function_type: string;
+  type: string;
+}
+export async function GET(request: NextRequest) {
+  const searchParams = request.nextUrl.searchParams;
+  const gameId = toBigInt(searchParams.get('gameId') as string);
+  try {
+    if (gameId === null) {
+      return new Response(`Missing parameters: gameId: ${gameId}`, {
+        status: 400,
+      });
+    }
+
+    const badgeDataRes = await supabase.rpc(
+      'get_all_badges',
+      {
+        _game_id: Number(gameId),
+      }
+    );
+    if (badgeDataRes.error) {
+      console.log(badgeDataRes.error);
+      return new Response('', { status: 500 });
+    }
+
+    const badgeData = badgeDataRes.data as unknown as BadgeDataType[];
+
+    return NextResponse.json(
+      mapToBadgeState(badgeData)
+    );
+  } catch (error) {
+    return NextResponse.json(
+      { error: `No available boosts found for gameId: ${gameId}` },
+      { status: 400 }
+    );
+  }
+}
+
+function mapToBadgeState(
+  badgeData: BadgeDataType[]
+): BadgeState[] {
+  return badgeData.map((badgeDataItem) => {
+    return {
+      badgeId: badgeDataItem.badge_id,
+      badgeName: badgeDataItem.badge_name,
+      challengeId: badgeDataItem.challenge_id,
+      checkFunction: badgeDataItem.function_type,
+      challengeType: badgeDataItem.type,
+    };
+  });
+}

--- a/src/hooks/types.ts
+++ b/src/hooks/types.ts
@@ -138,6 +138,14 @@ export type ChallengeMetricsState = {
   points: number;
 };
 
+export type BadgeState = {
+  badgeId: number;
+  badgeName: string;
+  challengeId: string;
+  checkFunction: string;
+  challengeType: string;
+};
+
 export type TreasureBoxState = {
   id: bigint;
   createdAt: Date;

--- a/src/utils/database.types.ts
+++ b/src/utils/database.types.ts
@@ -344,24 +344,72 @@ export type Database = {
       score: {
         Row: {
           current_score: number
-          game_id: number
+          game_id: number | null
           id: number
-          updated_at: string
-          user_address: string
+          updated_at: string | null
+          user_address: string | null
         }
         Insert: {
-          current_score?: number
-          game_id: number
+          current_score: number
+          game_id?: number | null
           id?: number
-          updated_at?: string
-          user_address: string
+          updated_at?: string | null
+          user_address?: string | null
         }
         Update: {
           current_score?: number
-          game_id?: number
+          game_id?: number | null
           id?: number
-          updated_at?: string
-          user_address?: string
+          updated_at?: string | null
+          user_address?: string | null
+        }
+        Relationships: []
+      }
+      score_greater_than_250: {
+        Row: {
+          current_score: number
+          game_id: number | null
+          id: number
+          updated_at: string | null
+          user_address: string | null
+        }
+        Insert: {
+          current_score: number
+          game_id?: number | null
+          id: number
+          updated_at?: string | null
+          user_address?: string | null
+        }
+        Update: {
+          current_score?: number
+          game_id?: number | null
+          id?: number
+          updated_at?: string | null
+          user_address?: string | null
+        }
+        Relationships: []
+      }
+      score_less_than_or_equal_to_250: {
+        Row: {
+          current_score: number
+          game_id: number | null
+          id: number
+          updated_at: string | null
+          user_address: string | null
+        }
+        Insert: {
+          current_score: number
+          game_id?: number | null
+          id: number
+          updated_at?: string | null
+          user_address?: string | null
+        }
+        Update: {
+          current_score?: number
+          game_id?: number | null
+          id?: number
+          updated_at?: string | null
+          user_address?: string | null
         }
         Relationships: []
       }
@@ -631,6 +679,12 @@ export type Database = {
       [_ in never]: never
     }
     Functions: {
+      get_all_badges: {
+        Args: {
+          _game_id: number
+        }
+        Returns: Json
+      }
       get_challenge_completion_count: {
         Args: {
           _game_id: number


### PR DESCRIPTION
Creating badges endpoint. This will fetch all the badges along with the `challengeId` for the challenge the badge belongs to. 

This was created so the frontend can know to render the badge challenges under the Earn Badges section 
 


<img width="369" alt="image" src="https://github.com/sizzle-squad/base-hunt/assets/143030165/ce735e18-5118-4832-b5db-28920267416d">

