### PR TITLE
fetch challenge info from explore when completing a challenge

### DIFF
--- a/src/app/api/challenges/complete/route.ts
+++ b/src/app/api/challenges/complete/route.ts
@@ -351,23 +351,23 @@ export async function POST(request: NextRequest) {
     );
   }
 
-  const params = challenge.params;
+  const { params } = challenge;
   params.tokenId = tokenId;
-  const d = {
+  const checkFuncData = {
     ...body,
-    ...(challenge as object),
+    ...challenge,
     contract_address: contractAddress,
     params,
   };
-  if (await checkFunc(d, provider)) {
+  if (await checkFunc(checkFuncData, provider)) {
     try {
       let userAddress =
         await MapChallengeTypeUserAddress[
           challenge.function_type as keyof typeof CheckFunctions
-        ](d);
+        ](checkFuncData);
       if (userAddress === undefined) {
         throw new Error(
-          'user address could not be mapped and is undefined:' + d
+          'user address could not be mapped and is undefined:' + checkFuncData
         );
       }
 


### PR DESCRIPTION
When the complete challenge endpoint is called, Call explore to fetch challenge information. We use `tokenId` `contractAddress` and `points` from explore. We will delete those colomns from our challenge_configuration table