### PR TITLE
use main db and not read replica

### DIFF
--- a/src/app/api/challenges/completion/route.ts
+++ b/src/app/api/challenges/completion/route.ts
@@ -6,7 +6,7 @@ import { toBigInt } from '@/utils/toBigInt';
 import { ChallengeStatus } from '@/utils/database.enums';
 
 const supabase = createClient<Database>(
-  process.env.SUPABASE_READ_REPLICA_URL as string,
+  process.env.SUPABASE_URL as string,
   process.env.SUPABASE_SERVICE_KEY as string
 );
 

--- a/src/app/api/leaderboard/rank/route.ts
+++ b/src/app/api/leaderboard/rank/route.ts
@@ -11,7 +11,7 @@ type RankType = {
 };
 
 const supabase = createClient(
-  process.env.SUPABASE_READ_REPLICA_URL as string,
+  process.env.SUPABASE_URL as string,
   process.env.SUPABASE_SERVICE_KEY as string
 );
 

--- a/src/app/api/leaderboard/route.ts
+++ b/src/app/api/leaderboard/route.ts
@@ -6,7 +6,7 @@ import { Database } from '@/utils/database.types';
 import { toBigInt } from '@/utils/toBigInt';
 
 const supabase = createClient<Database>(
-  process.env.SUPABASE_READ_REPLICA_URL as string,
+  process.env.SUPABASE_URL as string,
   process.env.SUPABASE_SERVICE_KEY as string
 );
 


### PR DESCRIPTION
We will no longer need to use the read replica since our main DB is optimized enough. Removing references to our read replica so we can delete it and save costs